### PR TITLE
added install-exec-local target. Note: linker should always go to /bin/l...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ALL_LOCAL =
 CLEAN_LOCAL =
-INSTALL_LOCAL =
+INSTALL_EXEC_LOCAL =
 
 include mk/rules.mk
 include libc/Makefile.syscalls.am
@@ -15,4 +15,4 @@ include libc/zoneinfo/Makefile.am
 
 all-local: $(ALL_LOCAL)
 clean-local: $(CLEAN_LOCAL)
-#install-local: $(INSTALL_LOCAL)
+install-exec-local: $(INSTALL_EXEC_LOCAL)

--- a/libc/Makefile.am
+++ b/libc/Makefile.am
@@ -614,14 +614,14 @@ libc_ldlibs = -ldl -lgcc
 
 $(foreach f,$(libc_dynamic_src), $(eval $(call compile-one-file,$(f),libc_dynamic,$(libc_dynamic_dep))))
 
+.PHONY: libc-all libc-clean libc-install-exec-local
+
 $(top_builddir)/libc/libc.a: $(libc_static_obj) $(libc_common_obj) $(SYSCALLS_STAMP) 
 	mkdir -p $(dir $@)
 	@AR@ crsP $@ $^
 
 $(top_builddir)/libc/libc.so: $(libc_dynamic_obj) $(libc_common_obj)
 	@CC@ $(libc_ldflags) -o $@ $(libc_dynamic_obj) $(libc_common_obj) $(libc_ldlibs)
-
-.PHONY: libc-all libc-clean
 
 libc-all: $(SYSCALLS_STAMP) $(top_builddir)/libc/libc.a $(top_builddir)/libc/libc.so
 
@@ -631,5 +631,10 @@ libc-clean:
 		$(libc_dynamic_obj) $(top_builddir)/libc/libc.so \
 		$(libc_dynamic_src_files)
 
+libc-install-exec-local: libc-all
+	$(INSTALL) -D $(top_builddir)/libc/libc.a $(DESTDIR)$(libdir)/libc.a
+	$(INSTALL) -D $(top_builddir)/libc/libc.so $(DESTDIR)$(libdir)/libc.so
+
 ALL_LOCAL += libc-all
 CLEAN_LOCAL += libc-clean
+INSTALL_EXEC_LOCAL += libc-install-exec-local

--- a/libc/Makefile.crt.am
+++ b/libc/Makefile.crt.am
@@ -70,15 +70,17 @@ crtend_android_cflags = $(libc_crt_target_so_cflags)
 $(eval $(call compile-one-file,libc/arch-@TARGET_ARCH@/bionic/crtend_android.S,crtend_android))
 CRTFILES += $(crtend_android_obj)
 
-.PHONY: crtfiles-all crtfiles-clean crtfiles-install
+.PHONY: crtfiles-all crtfiles-clean crtfiles-install-exec-local
 
 crtfiles-all: $(CRTFILES)
 
 crtfiles-clean:
 	rm -f $(CRTFILES)
 
-crtfiles-install:
-	mkdir -p $(DESTDIR)
+crtfiles-install-exec-local: crtfiles-all
+	$(INSTALL) -d $(DESTDIR)$(libdir)
+	$(INSTALL) -t $(DESTDIR)$(libdir) $(CRTFILES)
 
 ALL_LOCAL += crtfiles-all
 CLEAN_LOCAL += crtfiles-clean
+INSTALL_EXEC_LOCAL += crtfiles-install-exec-local

--- a/libdl/Makefile.am
+++ b/libdl/Makefile.am
@@ -6,7 +6,7 @@ libdl_dep = $(CRTFILES)
 
 $(foreach f,$(libdl_src), $(eval $(call compile-one-file,$(f),libdl,$(libdl_dep))))
 
-.PHONY: libdl-all-local libdl-clean-local
+.PHONY: libdl-all-local libdl-clean-local libdl-install-exec-local
 
 $(top_builddir)/libdl/libdl.a: $(libdl_obj)
 	mkdir -p $(dir $@)
@@ -20,5 +20,10 @@ libdl-all: $(top_builddir)/libdl/libdl.a $(top_builddir)/libdl/libdl.so
 libdl-clean:
 	rm -f $(libdl_obj) $(top_builddir)/libdl/libdl.a $(top_builddir)/libdl/libdl.so
 
+libdl-install-exec-local: libdl-all
+	$(INSTALL) -D $(top_builddir)/libdl/libdl.a $(DESTDIR)$(libdir)/libdl.a
+	$(INSTALL) -D $(top_builddir)/libdl/libdl.so $(DESTDIR)$(libdir)/libdl.so
+
 ALL_LOCAL += libdl-all
 CLEAN_LOCAL += libdl-clean
+INSTALL_EXEC_LOCAL += libdl-install-exec-local

--- a/libm/Makefile.am
+++ b/libm/Makefile.am
@@ -191,12 +191,17 @@ $(top_builddir)/libm/libm.a: $(libm_obj)
 $(top_builddir)/libm/libm.so: $(libm_obj) $(libm_dependencies)
 	@CC@ $(libm_ldflags) -o $@ $(libm_obj) $(libm_ldlibs)
 
-.PHONY: libm-all-local libm-clean-local
+.PHONY: libm-all-local libm-clean-local libm-install-exec-local
 
 libm-all: $(top_builddir)/libm/libm.a $(top_builddir)/libm/libm.so
 
 libm-clean:
 	rm -f $(libm_obj) $(top_builddir)/libm/libm.a $(top_builddir)/libm/libm.so
 
+libm-install-exec-local: libm-all
+	$(INSTALL) -D $(top_builddir)/libm/libm.a $(DESTDIR)$(libdir)/libm.a
+	$(INSTALL) -D $(top_builddir)/libm/libm.so $(DESTDIR)$(libdir)/libm.so
+
 ALL_LOCAL += libm-all
 CLEAN_LOCAL += libm-clean
+INSTALL_EXEC_LOCAL += libm-install-exec-local

--- a/libstdc++/Makefile.am
+++ b/libstdc++/Makefile.am
@@ -16,7 +16,7 @@ libstdc++_obj =
 
 $(foreach f,$(libstdc++_src), $(eval $(call compile-one-file,$(f),libstdc++,$(libstdc++_dep))))
 
-.PHONY: libstdc++-all-local libstdc++-clean-local
+.PHONY: libstdc++-all-local libstdc++-clean-local libstdc++-install-exec-local
 
 $(top_builddir)/libstdc++/libstdc++.a: $(libstdc++_obj)
 	mkdir -p $(dir $@)
@@ -30,5 +30,10 @@ libstdc++-all: $(SYSCALLS_STAMP) $(top_builddir)/libstdc++/libstdc++.a $(top_bui
 libstdc++-clean:
 	rm -f $(libstdc++_obj) $(top_builddir)/libstdc++/libstdc++.a $(top_builddir)/libstdc++/libstdc++.so
 
+libstdc++-install-exec-local: libstdc++-all
+	$(INSTALL) -D $(top_builddir)/libstdc++/libstdc++.a $(DESTDIR)$(libdir)/libstdc++.a
+	$(INSTALL) -D $(top_builddir)/libstdc++/libstdc++.so $(DESTDIR)$(libdir)/libstdc++.so
+
 ALL_LOCAL += libstdc++-all
 CLEAN_LOCAL += libstdc++-clean
+INSTALL_EXEC_LOCAL += libstdc++-install-exec-local

--- a/libthread_db/Makefile.am
+++ b/libthread_db/Makefile.am
@@ -23,7 +23,7 @@ libthread_db_dep = $(CRTFILES) libc-all
 
 $(foreach f,$(libthread_db_src), $(eval $(call compile-one-file,$(f),libthread_db,$(libthread_db_dep))))
 
-.PHONY: libthread_db-all-local libthread_db-clean-local
+.PHONY: libthread_db-all-local libthread_db-clean-local libthread_db-install-exec-local
 
 $(top_builddir)/libthread_db/libthread_db.a: $(libthread_db_obj)
 	mkdir -p $(dir $@)
@@ -37,5 +37,10 @@ libthread_db-all: $(top_builddir)/libthread_db/libthread_db.a $(top_builddir)/li
 libthread_db-clean:
 	rm -f $(libthread_db_obj) $(top_builddir)/libthread_db/libthread_db.a $(top_builddir)/libthread_db/libthread_db.so
 
+libthread_db-install-exec-local: libthread_db-all
+	$(INSTALL) -D $(top_builddir)/libthread_db/libthread_db.a $(DESTDIR)$(libdir)/libthread_db.a
+	$(INSTALL) -D $(top_builddir)/libthread_db/libthread_db.so $(DESTDIR)$(libdir)/libthread_db.so
+
 ALL_LOCAL += libthread_db-all
 CLEAN_LOCAL += libthread_db-clean
+INSTALL_EXEC_LOCAL += libthread_db-install-exec-local

--- a/linker/Makefile.am
+++ b/linker/Makefile.am
@@ -39,7 +39,7 @@ $(foreach f,$(linker_src), $(eval $(call compile-one-file,$(f),linker,$(linker_d
 $(top_builddir)/linker/linker: $(begin_obj) $(linker_obj) libc-all
 	@CC@ -o $@ $(linker_ldflags) $(begin_obj) $(linker_obj) $(linker_ldlibs)
 
-.PHONY: linker-all linker-clean linker-install
+.PHONY: linker-all linker-clean linker-install linker-install-exec-local
 
 linker-all: $(top_builddir)/linker/linker
 
@@ -48,5 +48,9 @@ linker-clean:
 		$(linker_obj) \
 		$(begin_obj)
 
+linker-install-exec-local: linker-all
+	$(INSTALL) -D $(top_builddir)/linker/linker $(DESTDIR)/$(bindir)/linker
+
 ALL_LOCAL += linker-all
 CLEAN_LOCAL += linker-clean
+INSTALL_EXEC_LOCAL += linker-install-exec-local


### PR DESCRIPTION
...inker - not /usr/bin/linker. Packagers will need to set bindir appropriately before calling configure. Likewise, as libraries should typically be installed in /usr, the packager should be aware that they should symlink /usr/lib/libc.so to /lib/libc.so and so on
