### PR TITLE
Revert "fix issue #37: non-PIC bug has shown up again"

### DIFF
--- a/libc/tools/gensyscalls.py
+++ b/libc/tools/gensyscalls.py
@@ -72,7 +72,7 @@ x86_call = """    movl    $%(idname)s, %%eax
     jb      1f
     negl    %%eax
     pushl   %%eax
-    call    PIC_PLT(__set_errno)
+    call    __set_errno
     addl    $4, %%esp
     orl     $-1, %%eax
 1:


### PR DESCRIPTION
This reverts commit 125b0241775abdcaee952348e1d701f7ea25ca1a.

When PIC_PLT(__set_errno) is called instead of simply __set_errno, a
segfault occurs. Need to determine why!

Bad Chris!!
